### PR TITLE
require johnpbloch/wordpress-core-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "source": "http://core.trac.wordpress.org/browser"
     },
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "johnpbloch/wordpress-core-installer": "~0.1"
     }
 }


### PR DESCRIPTION
require johnpbloch/wordpress-core-installer, make it easy to custom paths of wordpress-core