### PR TITLE
Bump minimum PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "source": "http://core.trac.wordpress.org/browser"
   },
   "require": {
-    "php": ">=5.3.2"
+    "php": ">=5.6.20"
   },
   "provide": {
     "wordpress/core-implementation": "dev-master"


### PR DESCRIPTION
As of WordPress 5.2, the system requires PHP 5.6. See https://wordpress.org/news/2019/04/minimum-php-version-update.

Also see https://github.com/johnpbloch/wordpress/pull/43.